### PR TITLE
Environment markers to avoid installing enum34 on Python 3.4+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,9 +36,15 @@ tests_require = [
 
 def get_install_requirements():
     install_requires = ['setuptools']
-    if sys.version_info < (3, 4):
+    if 'bdist_wheel' not in sys.argv and sys.version_info < (3, 4):
         install_requires.append('enum34')
     return install_requires
+
+
+def get_extras_require():
+    """Generate conditional requirements with environ marker."""
+    for pyversion in '2.5', '2.6', '2.7', '3.2', '3.3':
+        yield ':python_version==' + repr(pyversion), ['enum34']
 
 
 setup(
@@ -54,9 +60,10 @@ setup(
     url='http://github.com/spoqa/iso-3166-1',
     keywords='internationalization i18n country iso3166',
     install_requires=get_install_requirements(),
-    extras_require={
-        'tests': tests_require,
-    },
+    extras_require=dict(
+        get_extras_require(),
+        tests=tests_require
+    ),
     tests_require=tests_require,
     classifiers=[
         'Development Status :: 1 - Planning',


### PR DESCRIPTION
The standard `enum` module was introduced in Python 3.4, and enum34 package is just a backport of it for previous Python versions.

The existing approach to avoid installing enum34 on Python 3.4+ is dynamic generation of `install_requires` list in setup.py, and although it does work on sdist (*.tar.gz), but won’t work anymore on wheels.

The recommended approach to the problem for wheels is [environment markers](https://www.python.org/dev/peps/pep-0426/#environment-markers).  This patch makes setup.py to make proper `extra_requires` metadata.
