### PR TITLE
Fix setuptools version to 20.1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ tests_require = [
 
 
 def get_install_requirements():
-    install_requires = ['setuptools']
+    install_requires = ['setuptools==20.1.1']
     if 'bdist_wheel' not in sys.argv and sys.version_info < (3, 4):
         install_requires.append('enum34')
     return install_requires


### PR DESCRIPTION
- setuptools 20.2.1 cannot parse 'lib > 0.1, <= 1.0' in requirements
- see this issue on https://bitbucket.org/pypa/setuptools/issues/501/error-installing-zopeapppublication-with
